### PR TITLE
Allow settings to be updated after importing fetcher components

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ All the original static methods of the component are hoisted.
 
 ### `fetch.setup(options)`
 
-A function that allows you configure the behavior of future fetchers. For details on the `options` available for `fetch.setup()`, see `fetch()` above.
+A function that allows you configure the behavior of fetchers globally. For details on the `options` available for `fetch.setup()`, see `fetch()` above.
 
-All subsequent `fetch` calls will use the new settings, unless overridden by the individual calls.
+#### Remarks
 
-It's recommended that you call this function before decorating your components.
+* It will modify the behavior of fetcher components that are not mounted. Therefore, if you import a fetcher component returned by `fetch()` and then call `fetch.setup()` it will still change the behavior of that component.
 
 ### `fetchRouteData(store, components)`
 

--- a/test/specs/components/fetch.js
+++ b/test/specs/components/fetch.js
@@ -109,24 +109,34 @@ describe('fetch(getInitialAsyncState, options)', () => {
 describe('fetch.setup(options)', () => {
   it('should overwrite default loading component', () => {
     const ActivityIndicator = () => <div className="loading" />;
-    fetch.setup({ renderLoading: () => <ActivityIndicator /> });
     const getInitialAsyncState = sinon.stub().returns(new Promise(() => {}));
     const WrappedComponent = fetch(getInitialAsyncState, {
       forceInitialFetch: true,
     })(Component);
+
+    // Purposely placed after `Component` is decorated with `fetch` to ensure settings can be
+    // overwritten after component class is defined. However, not after the component is mounted.
+    fetch.setup({ renderLoading: () => <ActivityIndicator /> });
+
     const { wrapper } = mountWithStore(<WrappedComponent />);
+
     expect(wrapper.find(Spinner)).to.have.length(0);
     expect(wrapper.find(ActivityIndicator)).to.have.length(1);
   });
 
   it('should overwrite default failure component', (done) => {
     const Boom = () => <div className="boom" />;
-    fetch.setup({ renderFailure: () => <Boom /> });
     const getInitialAsyncState = sinon.stub().returns(Promise.reject());
     const WrappedComponent = fetch(getInitialAsyncState, {
       forceInitialFetch: true,
     })(Component);
+
+    // Purposely placed after `Component` is decorated with `fetch` to ensure settings can be
+    // overwritten after component class is defined. However, not after the component is mounted.
+    fetch.setup({ renderFailure: () => <Boom /> });
+
     const { wrapper } = mountWithStore(<WrappedComponent />);
+
     waitFor(
       () => wrapper.state('isFetching') === false,
       'Data fetching timed out',


### PR DESCRIPTION
This addresses an issue where calling `fetch.setup()` after importing the fetcher component returned from `fetch()` does not affect the fetcher component ever.
