### PR TITLE
Added response into formatError utility

### DIFF
--- a/src/formatError.js
+++ b/src/formatError.js
@@ -4,6 +4,7 @@ export default function formatError(error) {
   if (!isError(error)) return error;
   return {
     message: error.message,
+    response: error.response,
     name: error.name,
     stack: error.stack,
   };


### PR DESCRIPTION
Rollbar errors require more detail. I've added the response into the formattingError utility object in redux-fetch. This will eventually be consumed by [interal-server-error.jsx](https://github.com/flowcommerce/checkout/blob/f3e0a1a42fad109b4bcb44328ba225d543992e7e/client/components/internal-server-error.jsx) which is already looking for a response error object.